### PR TITLE
Add coder/configure example

### DIFF
--- a/configure/Dockerfile.ubuntu
+++ b/configure/Dockerfile.ubuntu
@@ -1,0 +1,5 @@
+FROM ubuntu:latest
+
+RUN apt-get update && apt-get install -y curl
+
+COPY [ "configure", "/coder/configure" ]

--- a/configure/configure
+++ b/configure/configure
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Configurations that depend on the $HOME directory
+
+## Install NVM, but only if it's not already installed
+if [ ! -d $HOME/.nvm ]; then
+  echo "Installing NVM"
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
+else
+  echo "NVM is already installed"
+fi


### PR DESCRIPTION
# Summary

Creates an example that uses `coder/configure` to install NVM

## Description and Context

Adds a directory configure/ containing example files for publishing images that make use of Coder's configure feature. If an image contains a script called "configure" in the directory "/coder", it is automatically run during environment builds. The main use-case is
configurations that depend on the $HOME directory that cannot otherwise be added to an image's Dockerfile.

### Want to Test this Image?

I created this publicly under my own account name at: https://hub.docker.com/repository/docker/vapurrmaid/coder