### PR TITLE
Update images

### DIFF
--- a/goland/Dockerfile.centos
+++ b/goland/Dockerfile.centos
@@ -1,7 +1,14 @@
 FROM centos:8
 
 RUN yum update -y && yum install -y \
+    which \
+    git \
+    bash \
     curl \
+    man \
+    vim \
+    sudo \
+    gnupg \
     # The following libraries are required for the IDE to be able to communicate with
     # code-server through xserver messaging.
     openssl \
@@ -9,11 +16,17 @@ RUN yum update -y && yum install -y \
     libXrender \
     fontconfig \
     libXi \
-    gtk3
+    gtk3 \
+    libGL
 
 # Install goland.
 RUN mkdir -p /opt/goland
-RUN curl -L https://download.jetbrains.com/go/goland-2019.3.3.tar.gz | tar -C /opt/goland --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=GO&latest&distribution=linux" | tar -C /opt/goland --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the goland startup script.
 RUN ln -s /opt/goland/bin/goland.sh /usr/bin/goland
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/goland/Dockerfile.ubuntu
+++ b/goland/Dockerfile.ubuntu
@@ -1,9 +1,19 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    git \
+    bash \
     curl \
-    # The following libraries are required for the IDE to be able to communicate with
-    # code-server through xserver messaging.
+    htop \
+    man \
+    vim \
+    ssh \
+    sudo \
+    lsb-release \
+    ca-certificates \
+    locales \
+    gnupg \
+    # Packages required for multi-editor support
     libxtst6 \
     libxrender1 \
     libfontconfig1 \
@@ -12,7 +22,12 @@ RUN apt-get update && apt-get install -y \
 
 # Install goland.
 RUN mkdir -p /opt/goland
-RUN curl -L https://download.jetbrains.com/go/goland-2019.3.3.tar.gz | tar -C /opt/goland --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=GO&latest&distribution=linux" | tar -C /opt/goland --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the goland startup script.
 RUN ln -s /opt/goland/bin/goland.sh /usr/bin/goland
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser --gecos '' --disabled-password coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/intellij/Dockerfile.centos
+++ b/intellij/Dockerfile.centos
@@ -1,7 +1,14 @@
 FROM centos:8
 
 RUN yum update -y && yum install -y \
+    which \
+    git \
+    bash \
     curl \
+    man \
+    vim \
+    sudo \
+    gnupg \
     # The following libraries are required for the IDE to be able to communicate with
     # code-server through xserver messaging.
     openssl \
@@ -9,11 +16,17 @@ RUN yum update -y && yum install -y \
     libXrender \
     fontconfig \
     libXi \
-    gtk3
+    gtk3 \
+    libGL
 
 # Install intellij.
 RUN mkdir -p /opt/idea
-RUN curl -L https://download.jetbrains.com/idea/ideaIC-2019.3.3.tar.gz | tar -C /opt/idea --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=IIC&latest&distribution=linux" | tar -C /opt/idea --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the intellij startup script.
-RUN ln -s /opt/intellij/bin/intellij.sh /usr/bin/intellij-idea-ultimate
+RUN ln -s /opt/idea/bin/idea.sh /usr/bin/intellij-idea-ultimate
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/intellij/Dockerfile.ubuntu
+++ b/intellij/Dockerfile.ubuntu
@@ -1,9 +1,19 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    git \
+    bash \
     curl \
-    # The following libraries are required for the IDE to be able to communicate with
-    # code-server through xserver messaging.
+    htop \
+    man \
+    vim \
+    ssh \
+    sudo \
+    lsb-release \
+    ca-certificates \
+    locales \
+    gnupg \
+    # Packages required for multi-editor support
     libxtst6 \
     libxrender1 \
     libfontconfig1 \
@@ -12,7 +22,12 @@ RUN apt-get update && apt-get install -y \
 
 # Install intellij.
 RUN mkdir -p /opt/idea
-RUN curl -L https://download.jetbrains.com/idea/ideaIC-2019.3.3.tar.gz | tar -C /opt/idea --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=IIC&latest&distribution=linux" | tar -C /opt/idea --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the intellij startup script.
 RUN ln -s /opt/idea/bin/idea.sh /usr/bin/intellij-idea-community
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser --gecos '' --disabled-password coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/jupyter/Dockerfile.centos
+++ b/jupyter/Dockerfile.centos
@@ -1,7 +1,14 @@
 FROM centos:8
 
 RUN yum update -y && yum install -y \
+    which \
+    sudo \
     python36
 
 # Install jupyter
 RUN pip3 install jupyterlab
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/jupyter/Dockerfile.centos
+++ b/jupyter/Dockerfile.centos
@@ -2,7 +2,13 @@ FROM centos:8
 
 RUN yum update -y && yum install -y \
     which \
+    git \
+    bash \
+    curl \
+    man \
+    vim \
     sudo \
+    gnupg \
     python36
 
 # Install jupyter

--- a/jupyter/Dockerfile.ubuntu
+++ b/jupyter/Dockerfile.ubuntu
@@ -1,7 +1,18 @@
 FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    git \
+    bash \
+    curl \
+    htop \
+    man \
+    vim \
+    ssh \
     sudo \
+    lsb-release \
+    ca-certificates \
+    locales \
+    gnupg \
     python3 \
     python3-pip
 

--- a/jupyter/Dockerfile.ubuntu
+++ b/jupyter/Dockerfile.ubuntu
@@ -1,9 +1,14 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y \
+    sudo \
     python3 \
     python3-pip
 
 # Install jupyter
 RUN pip3 install jupyterlab
 
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser --gecos '' --disabled-password coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/pycharm/Dockerfile.centos
+++ b/pycharm/Dockerfile.centos
@@ -1,7 +1,14 @@
 FROM centos:8
 
 RUN yum update -y && yum install -y \
+    which \
+    git \
+    bash \
     curl \
+    man \
+    vim \
+    sudo \
+    gnupg \
     # The following libraries are required for the IDE to be able to communicate with
     # code-server through xserver messaging.
     openssl \
@@ -9,11 +16,17 @@ RUN yum update -y && yum install -y \
     libXrender \
     fontconfig \
     libXi \
-    gtk3
+    gtk3 \
+    libGL
 
 # Install pycharm.
 RUN mkdir -p /opt/pycharm
-RUN curl -L https://download.jetbrains.com/python/pycharm-community-2019.3.4.tar.gz | tar -C /opt/pycharm --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=PCC&latest&distribution=linux" | tar -C /opt/pycharm --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the pycharm startup script.
 RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/pycharm/Dockerfile.ubuntu
+++ b/pycharm/Dockerfile.ubuntu
@@ -1,9 +1,19 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    git \
+    bash \
     curl \
-    # The following libraries are required for the IDE to be able to communicate with
-    # code-server through xserver messaging.
+    htop \
+    man \
+    vim \
+    ssh \
+    sudo \
+    lsb-release \
+    ca-certificates \
+    locales \
+    gnupg \
+    # Packages required for multi-editor support
     libxtst6 \
     libxrender1 \
     libfontconfig1 \
@@ -12,7 +22,12 @@ RUN apt-get update && apt-get install -y \
 
 # Install pycharm.
 RUN mkdir -p /opt/pycharm
-RUN curl -L https://download.jetbrains.com/python/pycharm-community-2019.3.4.tar.gz | tar -C /opt/pycharm --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=PCC&latest&distribution=linux" | tar -C /opt/pycharm --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the pycharm startup script.
 RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser --gecos '' --disabled-password coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/webstorm/Dockerfile.centos
+++ b/webstorm/Dockerfile.centos
@@ -1,7 +1,14 @@
 FROM centos:8
 
 RUN yum update -y && yum install -y \
+    which \
+    git \
+    bash \
     curl \
+    man \
+    vim \
+    sudo \
+    gnupg \
     # The following libraries are required for the IDE to be able to communicate with
     # code-server through xserver messaging.
     openssl \
@@ -9,11 +16,17 @@ RUN yum update -y && yum install -y \
     libXrender \
     fontconfig \
     libXi \
-    gtk3
+    gtk3 \
+    libGL
 
 # Install webstorm.
 RUN mkdir -p /opt/webstorm
-RUN curl -L https://download.jetbrains.com/webstorm/WebStorm-2019.3.3.tar.gz | tar -C /opt/webstorm --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=WS&latest&distribution=linux" | tar -C /opt/webstorm --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the webstorm startup script.
 RUN ln -s /opt/webstorm/bin/webstorm.sh /usr/bin/webstorm
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder

--- a/webstorm/Dockerfile.ubuntu
+++ b/webstorm/Dockerfile.ubuntu
@@ -1,9 +1,19 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    git \
+    bash \
     curl \
-    # The following libraries are required for the IDE to be able to communicate with
-    # code-server through xserver messaging.
+    htop \
+    man \
+    vim \
+    ssh \
+    sudo \
+    lsb-release \
+    ca-certificates \
+    locales \
+    gnupg \
+    # Packages required for multi-editor support
     libxtst6 \
     libxrender1 \
     libfontconfig1 \
@@ -12,7 +22,12 @@ RUN apt-get update && apt-get install -y \
 
 # Install webstorm.
 RUN mkdir -p /opt/webstorm
-RUN curl -L https://download.jetbrains.com/webstorm/WebStorm-2019.3.3.tar.gz | tar -C /opt/webstorm --strip-components 1 -xzvf -
+RUN curl -L "https://download.jetbrains.com/product?code=WS&latest&distribution=linux" | tar -C /opt/webstorm --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the webstorm startup script.
 RUN ln -s /opt/webstorm/bin/webstorm.sh /usr/bin/webstorm
+
+# Add a user `coder` so that you're not developing as the `root` user
+RUN adduser --gecos '' --disabled-password coder && \
+  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
+USER coder


### PR DESCRIPTION
Update Images for Multi-Editor Support

- Add libraries for multi-editor in CentOS images (which, libGL)
- Add additional libraries to match documentation (git, bash, curl, etc...)
- Add user `coder` for CentOS and Ubuntu images
- Pull latest version of editor instead of fixed version (GoLand, IntelliJ, PyCharm and WebStorm)
- Update Ubuntu version to 20.04