### PR TITLE
Remove lsb-release

### DIFF
--- a/images/base/Dockerfile.arch
+++ b/images/base/Dockerfile.arch
@@ -16,7 +16,6 @@ RUN pacman --noconfirm -Syu \
     sudo \
     python3 \
     openssh \
-    lsb-release \
     ca-certificates
 
 # Add coder user.

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -18,7 +18,6 @@ RUN yum update -y && yum install -y \
     vim \
     sudo \
     python3 \
-    redhat-lsb-core \
     ca-certificates
 
 # Add a user `coder` so that you're not developing as the `root` user

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -13,7 +13,6 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     sudo \
     python3 \
     python3-pip \
-    lsb-release \
     ca-certificates \
     locales
 


### PR DESCRIPTION
We use `/etc/os-release` for OS info: https://github.com/cdr/c/blob/bc8fbd728f40a703ff39aa16b76709bd7fb1aa8c/rfcs/archive/0014-os-info.md