### PR TITLE
Add default ruby images

### DIFF
--- a/images/ruby/Dockerfile.centos
+++ b/images/ruby/Dockerfile.centos
@@ -1,0 +1,13 @@
+FROM codercom/enterprise-base:centos
+
+# Run everything as root
+USER root
+
+# Install Ruby
+RUN yum install -y ruby
+
+# Install bundler gem
+RUN gem install bundler
+
+# Set back to coder user
+USER coder

--- a/images/ruby/Dockerfile.centos
+++ b/images/ruby/Dockerfile.centos
@@ -3,8 +3,12 @@ FROM codercom/enterprise-base:centos
 # Run everything as root
 USER root
 
-# Install Ruby
-RUN yum install -y ruby
+# Install OpenSSL library
+RUN yum install -y openssl-devel
+
+# Install Ruby from source
+COPY ./install-ruby.sh /tmp
+RUN chmod +x /tmp/install-ruby.sh && /tmp/install-ruby.sh
 
 # Install bundler gem
 RUN gem install bundler

--- a/images/ruby/Dockerfile.ubuntu
+++ b/images/ruby/Dockerfile.ubuntu
@@ -3,11 +3,12 @@ FROM codercom/enterprise-base:ubuntu
 # Run everything as root
 USER root
 
-# Install Ruby
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y ruby-full
+# Install OpenSSL library
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y libssl-dev
 
-# Install bundler gem
-RUN gem install bundler
+# Install Ruby from source
+COPY ./install-ruby.sh /tmp
+RUN chmod +x /tmp/install-ruby.sh && /tmp/install-ruby.sh
 
 # Set back to coder user
 USER coder

--- a/images/ruby/Dockerfile.ubuntu
+++ b/images/ruby/Dockerfile.ubuntu
@@ -1,0 +1,13 @@
+FROM codercom/enterprise-base:ubuntu
+
+# Run everything as root
+USER root
+
+# Install Ruby
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y ruby-full
+
+# Install bundler gem
+RUN gem install bundler
+
+# Set back to coder user
+USER coder

--- a/images/ruby/install-ruby.sh
+++ b/images/ruby/install-ruby.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUBY_MAJOR=2.7
+RUBY_VERSION=2.7.2
+RUBY_SHA256=6e5706d0d4ee4e1e2f883db9d768586b4d06567debea353c796ec45e8321c3d4
+RUBY_DOWNLOAD_PATH=/tmp/ruby.tar.gz
+RUBY_SOURCE_DIR=/tmp/ruby-${RUBY_VERSION}
+
+echo "Downloading Ruby ${RUBY_VERSION}..."
+curl -fsSL -o ${RUBY_DOWNLOAD_PATH} https://cache.ruby-lang.org/pub/ruby/${RUBY_MAJOR}/ruby-${RUBY_VERSION}.tar.gz
+
+echo "Comparing downloaded file hash..."
+echo "${RUBY_SHA256}  ${RUBY_DOWNLOAD_PATH}" | sha256sum -c -
+
+echo "Unzipping Ruby..."
+tar -xzf $RUBY_DOWNLOAD_PATH -C /tmp
+
+echo "Installing Ruby..."
+pushd ${RUBY_SOURCE_DIR}
+./configure
+make
+make install
+popd


### PR DESCRIPTION
Adds images for ruby, using the distro's ruby packages. I initially wanted to do the installation via RVM so that they could easily switch versions, but I had a hell of a time getting RVM to install as root in Docker (seems to be a common problem.)

If anyone wants to take a better stab at this, be my guest.