### PR TITLE
Add default java images

### DIFF
--- a/images/base/Dockerfile.arch
+++ b/images/base/Dockerfile.arch
@@ -10,6 +10,7 @@ RUN pacman --noconfirm -Syu \
     bash \
     curl \
     wget \
+    unzip \
     htop \
     man \
     vim \

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -13,6 +13,7 @@ RUN yum update -y && yum install -y \
     bash \
     curl \
     wget \
+    unzip \
     htop \
     man \
     vim \

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -7,6 +7,7 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     bash \
     curl \
     wget \
+    unzip \
     htop \
     man \
     vim \

--- a/images/java/Dockerfile.centos
+++ b/images/java/Dockerfile.centos
@@ -1,0 +1,10 @@
+FROM codercom/enterprise-base:centos
+
+# Run everything as root
+USER root
+
+# Install JDK (OpenJDK 14)
+RUN yum install -y java-14-openjdk-devel
+
+# Set back to coder user
+USER coder

--- a/images/java/Dockerfile.centos
+++ b/images/java/Dockerfile.centos
@@ -3,8 +3,53 @@ FROM codercom/enterprise-base:centos
 # Run everything as root
 USER root
 
-# Install JDK (OpenJDK 14)
-RUN yum install -y java-14-openjdk-devel
+# Install JDK (OpenJDK 8)
+RUN yum install -y java-1.8.0-openjdk-devel
+ENV JAVA_HOME /usr/lib/jvm/java-1.8.0
+ENV PATH $PATH:$JAVA_HOME/bin
+
+# Install Maven
+ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_SHA512=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "/home/coder/.m2"
+
+RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
+  && echo "Downloading maven" \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  \
+  && echo "Checking downloaded file hash" \
+  && echo "${MAVEN_SHA512}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  \
+  && echo "Unzipping maven" \
+  && tar -xzf /tmp/apache-maven.tar.gz -C $MAVEN_HOME --strip-components=1 \
+  \
+  && echo "Cleaning and setting links" \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s $MAVEN_HOME/bin/mvn /usr/bin/mvn
+
+# Install Gradle
+ENV GRADLE_VERSION=6.7
+ARG GRADLE_SHA512=d495bc65379d2a854d2cca843bd2eeb94f381e5a7dcae89e6ceb6ef4c5835524932313e7f30d7a875d5330add37a5fe23447dc3b55b4d95dffffa870c0b24493
+
+ENV GRADLE_HOME /usr/bin/gradle
+
+RUN mkdir -p /usr/share/gradle /usr/share/gradle/ref \
+  && echo "Downloading gradle" \
+  && curl -fsSL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+  \
+  && echo "Checking downloaded file hash" \
+  && echo "${GRADLE_SHA512}  /tmp/gradle.zip" | sha512sum -c - \
+  \
+  && echo "Unziping gradle" \
+  && unzip -d /usr/share/gradle /tmp/gradle.zip \
+   \
+  && echo "Cleaning and setting links" \
+  && rm -f /tmp/gradle.zip \
+  && ln -s /usr/share/gradle/gradle-${GRADLE_VERSION} /usr/bin/gradle
+
+ENV PATH $PATH:$GRADLE_HOME/bin
 
 # Set back to coder user
 USER coder

--- a/images/java/Dockerfile.ubuntu
+++ b/images/java/Dockerfile.ubuntu
@@ -3,8 +3,53 @@ FROM codercom/enterprise-base:ubuntu
 # Run everything as root
 USER root
 
-# Install JDK (OpenJDK 14)
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-14-jdk
+# Install JDK (OpenJDK 8)
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-8-jdk
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV PATH $PATH:$JAVA_HOME/bin
+
+# Install Maven
+ARG MAVEN_VERSION=3.6.3
+ARG MAVEN_SHA512=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
+
+ENV MAVEN_HOME /usr/share/maven
+ENV MAVEN_CONFIG "/home/coder/.m2"
+
+RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
+  && echo "Downloading maven" \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  \
+  && echo "Checking downloaded file hash" \
+  && echo "${MAVEN_SHA512}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
+  \
+  && echo "Unzipping maven" \
+  && tar -xzf /tmp/apache-maven.tar.gz -C $MAVEN_HOME --strip-components=1 \
+  \
+  && echo "Cleaning and setting links" \
+  && rm -f /tmp/apache-maven.tar.gz \
+  && ln -s $MAVEN_HOME/bin/mvn /usr/bin/mvn
+
+# Install Gradle
+ENV GRADLE_VERSION=6.7
+ARG GRADLE_SHA512=d495bc65379d2a854d2cca843bd2eeb94f381e5a7dcae89e6ceb6ef4c5835524932313e7f30d7a875d5330add37a5fe23447dc3b55b4d95dffffa870c0b24493
+
+ENV GRADLE_HOME /usr/bin/gradle
+
+RUN mkdir -p /usr/share/gradle /usr/share/gradle/ref \
+  && echo "Downloading gradle" \
+  && curl -fsSL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip \
+  \
+  && echo "Checking downloaded file hash" \
+  && echo "${GRADLE_SHA512}  /tmp/gradle.zip" | sha512sum -c - \
+  \
+  && echo "Unziping gradle" \
+  && unzip -d /usr/share/gradle /tmp/gradle.zip \
+   \
+  && echo "Cleaning and setting links" \
+  && rm -f /tmp/gradle.zip \
+  && ln -s /usr/share/gradle/gradle-${GRADLE_VERSION} /usr/bin/gradle
+
+ENV PATH $PATH:$GRADLE_HOME/bin
 
 # Set back to coder user
 USER coder

--- a/images/java/Dockerfile.ubuntu
+++ b/images/java/Dockerfile.ubuntu
@@ -1,0 +1,10 @@
+FROM codercom/enterprise-base:ubuntu
+
+# Run everything as root
+USER root
+
+# Install JDK (OpenJDK 14)
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-14-jdk
+
+# Set back to coder user
+USER coder


### PR DESCRIPTION
Another simple one, just installs the highest JDK version that both CentOS and Ubuntu had in their repositories (14). We could go through the trouble of downloading 15 and manually installing, but this just seemed easiest.