### PR TITLE
Add image-specific READMEs with dockerhub badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ about supported editors and known issues.
 All of the images provided in this repo include the following utilities to ensure they work well
 with all of Coder Enterprise's features, and to provide a solid out-of-the-box developer experience:
 
-* git
-* bash
-* curl & wget
-* htop
-* man
-* vim
-* sudo
-* python3 & pip3
-* gcc & gcc-c++ & make
+- git
+- bash
+- curl & wget
+- htop
+- man
+- vim
+- sudo
+- python3 & pip3
+- gcc & gcc-c++ & make
 
 ## Images on Docker Hub
 

--- a/images/base/README.md
+++ b/images/base/README.md
@@ -1,0 +1,11 @@
+# Enterprise Base
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-base?label=codercom%2Fenterprise-base)](https://hub.docker.com/r/codercom/enterprise-base)
+
+## Description
+
+Base images from which all other images in this repository extend from.
+
+## How To Use It
+
+Extend this image with additional tooling and language packages.

--- a/images/configure/README.md
+++ b/images/configure/README.md
@@ -1,0 +1,16 @@
+# Coder Configure
+
+## Description
+
+This directory contains an example [image](./Dockerfile.ubuntu) and [configure](./configure)
+script. The configure script is used to add [`nvm`](https://github.com/nvm-sh/nvm) to a Coder environment.
+
+## How To Use It
+
+If an image contains an executable script located at `/coder/configure`, it is
+automatically detected and executed by Coder environments during the build
+process.
+
+## Further Reading
+
+Our support site contains [a tutorial](https://help.coder.com/hc/en-us/articles/360055782794-Configuring-Your-Environment-on-Startup) on Coder Configure.

--- a/images/goland/README.md
+++ b/images/goland/README.md
@@ -1,0 +1,12 @@
+# Enterprise GoLand
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-goland?label=codercom%2Fenterprise-goland)](https://hub.docker.com/r/codercom/enterprise-goland)
+
+## Description
+
+Wraps [enterprise-multieditor](../multieditor/README.md) with GoLand installation.
+
+## How To Use It
+
+This image is ready for direct use within Coder Enterprise. Environments
+created from this image will be able to launch GoLand.

--- a/images/golang/README.md
+++ b/images/golang/README.md
@@ -1,0 +1,14 @@
+# Enterprise Golang
+
+[![DockerPulls](https://img.shields.io/docker/pulls/codercom/enterprise-golang)](https://hub.docker.com/r/codercom/enterprise-golang)
+
+## Description
+
+Wraps [enterprise-base](../base/README.md) with the basics for Go development.
+
+> **Note:** This image does not contain GoLand. For an example of how to install
+> GoLand, see [enterprise-goland](../goland/README.md)
+
+## How To Use
+
+This image is ready for direct use within Coder Enterprise.

--- a/images/intellij/README.md
+++ b/images/intellij/README.md
@@ -1,0 +1,12 @@
+# Enterprise IntelliJ
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-intellij?label=codercom%2Fenterprise-intellij)](https://hub.docker.com/r/codercom/enterprise-intellij)
+
+## Description
+
+Wraps [enterprise-multieditor](../multieditor/README.md) with IntelliJ installation.
+
+## How To Use It
+
+This image is ready for direct use within Coder Enterprise. Environments
+created from this image will be able to launch IntelliJ IDEA.

--- a/images/java/README.md
+++ b/images/java/README.md
@@ -1,0 +1,14 @@
+# Enterprise Java
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-java?label=codercom%2Fenterprise-java)](https://hub.docker.com/r/codercom/enterprise-java)
+
+## Description
+
+Wraps [enterprise-base](../base/README.md) with the basics for Java development.
+
+> **Note:** This image does not contain IntelliJ. For an example of how to install
+> IntelliJ, see [enterprise-intellij](../intellij/README.md)
+
+## How To Use
+
+This image is ready for direct use within Coder Enterprise.

--- a/images/jupyter/README.md
+++ b/images/jupyter/README.md
@@ -1,0 +1,12 @@
+# Enterprise Jupyter
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-jupyter?label=codercom%2Fenterprise-jupyter)](https://hub.docker.com/r/codercom/enterprise-jupyter)
+
+## Description
+
+Wraps [enterprise-base](../base/README.md) with Jupyter installation.
+
+## How To Use It
+
+This image is ready for direct use within Coder Enterprise. Environments
+created from this image will be able to launch Jupyter.

--- a/images/multieditor/README.md
+++ b/images/multieditor/README.md
@@ -1,0 +1,12 @@
+# Enterprise Multi Editor
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-multieditor?label=codercom%2Fenterprise-multieditor)](https://hub.docker.com/r/codercom/enterprise-multieditor)
+
+## Description
+
+By default, Coder Enterprise supports [`code-server`](https://github.com/cdr/code-server) and a terminal application. Additional IDEs [require dependencies](https://enterprise.coder.com/docs/installing-an-ide-onto-your-image#required-packages). This image builds on [enterprise-base](../base/README.md) image by adding those additional dependencies.
+
+## How To Use It
+
+This image should be extended with the installation of an IDE. For example, see
+our [enterprise-goland:ubuntu](../goland/Dockerfile.ubuntu).

--- a/images/node/README.md
+++ b/images/node/README.md
@@ -1,0 +1,11 @@
+# Enterprise Node
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-node?label=codercom%2Fenterprise-node)](https://hub.docker.com/r/codercom/enterprise-node)
+
+## Description
+
+Wraps [enterprise-base](../base/README.md) with the basics for Node development.
+
+## How To Use
+
+This image is ready for direct use within Coder Enterprise.

--- a/images/pycharm/README.md
+++ b/images/pycharm/README.md
@@ -1,0 +1,12 @@
+# Enterprise PyCharm
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-pycharm?label=codercom%2Fenterprise-pycharm)](https://hub.docker.com/r/codercom/enterprise-pycharm)
+
+## Description
+
+Wraps [enterprise-multieditor](../multieditor/README.md) with PyCharm installation.
+
+## How To Use It
+
+This image is ready for direct use within Coder Enterprise. Environments
+created from this image will be able to launch PyCharm.

--- a/images/webstorm/README.md
+++ b/images/webstorm/README.md
@@ -1,0 +1,12 @@
+# Enterprise WebStorm
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-webstorm?label=codercom%2Fenterprise-webstorm)](https://hub.docker.com/r/codercom/enterprise-webstorm)
+
+## Description
+
+Wraps [enterprise-multieditor](../multieditor/README.md) with WebStorm installation.
+
+## How To Use It
+
+This image is ready for direct use within Coder Enterprise. Environments
+created from this image will be able to launch WebStorm.


### PR DESCRIPTION
## Summary

Adds a badge, wrapped by a url, for each of our images. The badge content is the number of dockerhub pulls, and the link is to the image's home on dockerhub.

## Context

Thought it might be nice to add badges for the images in this repository. Unsure if we should select a subset (and if so, what the subset criteria is), so I got the ball rolling with having them all up for now.

