### PR TITLE
Start caching /var/lib/docker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,8 @@ jobs:
         name: Cache Docker layers
         uses: actions/cache@v2
         with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+          path: /var/lib/docker
+          key: ${{ runner.os }}-docker
       -
         name: Login to DockerHub
         uses: docker/login-action@v1 


### PR DESCRIPTION
Previous cache was setup for buildx, which we're not using anymore. This may result in _too_ aggressively caching, so we may want to setup an action for clearing the cache periodically.