### PR TITLE
fix(pycharm): Symlink pycharm -> pycharm-community

### DIFF
--- a/images/pycharm/Dockerfile.centos
+++ b/images/pycharm/Dockerfile.centos
@@ -8,7 +8,7 @@ RUN mkdir -p /opt/pycharm
 RUN curl -L "https://download.jetbrains.com/product?code=PCC&latest&distribution=linux" | tar -C /opt/pycharm --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the pycharm startup script.
-RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm
+RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm-community
 
 # Set back to coder user
 USER coder

--- a/images/pycharm/Dockerfile.ubuntu
+++ b/images/pycharm/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ RUN mkdir -p /opt/pycharm
 RUN curl -L "https://download.jetbrains.com/product?code=PCC&latest&distribution=linux" | tar -C /opt/pycharm --strip-components 1 -xzvf -
 
 # Add a binary to the PATH that points to the pycharm startup script.
-RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm
+RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm-community
 
 # Set back to coder user
 USER coder


### PR DESCRIPTION
## Context

codercom/enterprise-pycharm installs [pycharm community](https://github.com/cdr/enterprise-images/blob/98c24a3f55e3a69249f6f9d0921a57bc767d6cc1/images/pycharm/Dockerfile.ubuntu#L8) then registers the application to our jetrbrains [`code-server` plugin](https://github.com/cdr/code-server/blob/v3.8.0/typings/pluginapi.d.ts)

with

```Dockerfile
RUN ln -s /opt/pycharm/bin/pycharm.sh /usr/bin/pycharm
```

However, the expected symlink for our jetbrains `code-server` plugin is `pycharm-community`

## Coder Enterprise Outcomes

- `PyCharm Professional` will appear as the name of the application on the web client for what is really PyCharm Community. This will be fixed in versions > 1.15.x