### PR TITLE
chore: pin archlinux package versions

### DIFF
--- a/images/base/Dockerfile.arch
+++ b/images/base/Dockerfile.arch
@@ -1,6 +1,9 @@
-FROM archlinux/base
+FROM archlinux/archlinux:base-20210205.0.15146
 
 SHELL ["/bin/bash", "-c"]
+
+# Workaround broken upstream archive by pinning to older snapshot
+COPY mirrorlist /etc/pacman.d/mirrorlist
 
 # Install baseline packages
 RUN pacman --noconfirm -Syu \

--- a/images/base/mirrorlist
+++ b/images/base/mirrorlist
@@ -1,0 +1,1 @@
+Server=https://archive.archlinux.org/repos/2021/02/01/$repo/os/$arch


### PR DESCRIPTION
* Switch from deprecated archlinux/base to archlinux/archlinux
* Pin a specific base image and repository snapshot, as recent
  versions are inoperable under Coder due to a glibc upgrade
  (https://bugs.archlinux.org/task/69563)