### PR TITLE
chore: run and publish nightly image builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,6 +9,12 @@ on:
     branches:
       - main
 
+  schedule:
+    # Run at 2am UTC
+    - cron: "0 2 * * *"
+
+  workflow_dispatch:
+
 jobs:
   # Quick checks, running linters, checking formatting, etc
   quick:


### PR DESCRIPTION
* Add scheduled build to run at 2am UTC
* Enable manual build trigger (workflow_dispatch)