### PR TITLE
chore: optimize layers in base images

### DIFF
--- a/images/base/Dockerfile.arch
+++ b/images/base/Dockerfile.arch
@@ -6,31 +6,36 @@ SHELL ["/bin/bash", "-c"]
 COPY mirrorlist /etc/pacman.d/mirrorlist
 
 # Install baseline packages
-RUN pacman --noconfirm -Syu \
-    base \
-    base-devel \
-    docker \
-    git \
-    bash \
-    curl \
-    wget \
-    unzip \
-    htop \
-    man \
-    vim \
-    sudo \
-    python3 \
-    openssh \
-    ca-certificates
+RUN pacman --noconfirm -Syyuu \
+      base \
+      base-devel \
+      bash \
+      ca-certificates \
+      curl \
+      docker \
+      git \
+      htop \
+      man \
+      openssh \
+      python3 \
+      sudo \
+      unzip \
+      vim \
+      wget && \
+    # Delete package cache to avoid consuming space in layer
+    pacman --noconfirm -Scc
 
 # Enables Docker starting with systemd
 RUN systemctl enable docker
 
 # Add coder user.
-RUN useradd -mUs /bin/bash coder && \
-  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-RUN usermod -aG docker coder
+RUN useradd coder \
+      --create-home \
+      --shell=/bin/bash \
+      --groups=docker \
+      --uid=1000 \
+      --user-group && \
+    echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
 USER coder
 

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -3,9 +3,7 @@ FROM centos:8
 SHELL ["/bin/bash", "-c"]
 
 # Add the EPEL repolist
-RUN dnf --assumeyes install \
-      epel-release && \
-    dnf repolist && \
+RUN dnf install --assumeyes epel-release && \
     dnf upgrade --assumeyes --refresh && \
     dnf install --assumeyes \
       bash \

--- a/images/base/Dockerfile.centos
+++ b/images/base/Dockerfile.centos
@@ -1,38 +1,44 @@
 FROM centos:8
 
+SHELL ["/bin/bash", "-c"]
+
 # Add the EPEL repolist
-RUN yum -y install epel-release
-RUN yum repolist
+RUN dnf --assumeyes install \
+      epel-release && \
+    dnf repolist && \
+    dnf upgrade --assumeyes --refresh && \
+    dnf install --assumeyes \
+      bash \
+      ca-certificates \
+      curl \
+      device-mapper-persistent-data \
+      dnf-utils \
+      gcc \
+      gcc-c++ \
+      git \
+      htop \
+      lvm2 \
+      make \
+      man \
+      python3 \
+      sudo \
+      unzip \
+      vim \
+      wget && \
+    dnf clean all
 
-RUN yum update -y && yum install -y yum-utils device-mapper-persistent-data lvm2
-RUN yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-
-# Install baseline packages
-RUN yum update -y && yum install -y \
-    docker-ce \
-    gcc \
-    gcc-c++ \
-    make \
-    git \
-    bash \
-    curl \
-    wget \
-    unzip \
-    htop \
-    man \
-    vim \
-    sudo \
-    python3 \
-    ca-certificates
-
-# Enables Docker starting with systemd
-RUN systemctl enable docker
+RUN dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
+    dnf install --assumeyes docker-ce && \
+    systemctl enable docker
 
 # Add a user `coder` so that you're not developing as the `root` user
-RUN adduser coder && \
-  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-RUN usermod -aG docker coder
+RUN useradd coder \
+      --create-home \
+      --shell=/bin/bash \
+      --groups=docker \
+      --uid=1000 \
+      --user-group && \
+    echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
 USER coder
 

--- a/images/base/Dockerfile.ubuntu
+++ b/images/base/Dockerfile.ubuntu
@@ -1,8 +1,10 @@
 FROM ubuntu:20.04
 
+SHELL ["/bin/bash", "-c"]
+
 # Install baseline packages
 RUN apt-get update && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
       bash \
       build-essential \
       ca-certificates \
@@ -22,17 +24,19 @@ RUN apt-get update && \
       wget && \
     # Install latest Git using their official PPA
     add-apt-repository ppa:git-core/ppa && \
-    DEBIAN_FRONTEND="noninteractive" apt-get install -y git
-
+    DEBIAN_FRONTEND="noninteractive" apt-get install --yes git
 
 # Enables Docker starting with systemd
 RUN systemctl enable docker
 
 # Add a user `coder` so that you're not developing as the `root` user
-RUN adduser --gecos '' --disabled-password coder && \
-  echo "coder ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd
-
-RUN usermod -aG docker coder
+RUN useradd coder \
+      --create-home \
+      --shell=/bin/bash \
+      --groups=docker \
+      --uid=1000 \
+      --user-group && \
+    echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
 USER coder
 


### PR DESCRIPTION
* Reduce the number of layers in base images by consolidating
  related build steps
* Switch from yum to its successor, dnf, in the centos base image
* Delete package cache after installation to reduce image size
* Use bash to run Dockerfile build commands in centos and ubuntu
* Sort package dependencies alphabetically