### PR TITLE
add readme for vnc image

### DIFF
--- a/images/vnc/README.md
+++ b/images/vnc/README.md
@@ -5,12 +5,12 @@ A [sample image](https://github.com/cdr/enterprise-images/tree/main/images/vnc) 
 ## To connect
 
 - Option 1 (Web): Create a dev URL on port `6081` and navigate to it
-- Option 2 (SSH Tunneling): Use SSH tunneling to expose the VNC server to your local machine. You will need the [coder-cli](https://github.com/cdr/coder-cli), and a VNC client installed on your local machine.
+- Option 2 (SSH Tunneling): Use SSH tunneling to expose the VNC server to your local machine. You will need the [coder-cli](https://github.com/cdr/coder-cli) and a VNC client installed on your local machine.
 
     ```sh
     coder config-ssh
     # Forward the remote VNC server to your local machine
     ssh -L -N 5990:localhost:localhost:5990 coder.[env-name]
-    # You will not see an output if it succeeds
-    # Now, you can connect your VNC client to localhost:5990
+    # You will not see any output if it succeeds, but you
+    # will be able to connect your VNC client to localhost:5990
     ```

--- a/images/vnc/README.md
+++ b/images/vnc/README.md
@@ -9,6 +9,8 @@ A [sample image](https://github.com/cdr/enterprise-images/tree/main/images/vnc) 
 
     ```sh
     coder config-ssh
-    ssh -L 5990:localhost:localhost:5990 coder.[env-name]
-    # Connect VNC client to localhost:5990
+    # Forward the remote VNC server to your local machine
+    ssh -L -N 5990:localhost:localhost:5990 coder.[env-name]
+    # You will not see an output if it succeeds
+    # Now, you can connect your VNC client to localhost:5990
     ```

--- a/images/vnc/README.md
+++ b/images/vnc/README.md
@@ -1,0 +1,14 @@
+# VNC in Coder
+
+A [sample image](https://github.com/cdr/enterprise-images/tree/main/images/vnc) for Coder that uses [noVNC](https://github.com/novnc/noVNC) as the client and [TigerVNC](https://tigervnc.org) as the server.
+
+## To connect
+
+- Option 1 (Web): Create a dev URL on port `6081` and navigate to it
+- Option 2 (SSH Tunneling): Use SSH tunneling to expose the VNC server to your local machine. You will need the [coder-cli](https://github.com/cdr/coder-cli), and a VNC client installed on your local machine.
+
+    ```sh
+    coder config-ssh
+    ssh -L 5990:localhost:localhost:5990 coder.[env-name]
+    # Connect VNC client to localhost:5990
+    ```


### PR DESCRIPTION
The docs discusses the general setup, but does not mention specific ports for Dev URLs or VNC, as that varies depending on the image configuration: https://coder.com/docs/guides/customization/vnc

This readme instructs the user how to use this VNC image with Coder