### PR TITLE
fixes to VNC image

### DIFF
--- a/images/vnc/Dockerfile.ubuntu
+++ b/images/vnc/Dockerfile.ubuntu
@@ -49,10 +49,6 @@ RUN apt-get remove -y \
 
 RUN locale-gen en_US.UTF-8
 
-RUN curl -LO https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
-  && apt-get install -y ./google-chrome-stable_current_amd64.deb \
-  && rm google-chrome-stable_current_amd64.deb
-
 ARG HOME=/home/coder
 ARG VNC_ROOT_DIR=/opt/vnc
 

--- a/images/vnc/README.md
+++ b/images/vnc/README.md
@@ -10,7 +10,7 @@ A [sample image](https://github.com/cdr/enterprise-images/tree/main/images/vnc) 
     ```sh
     coder config-ssh
     # Forward the remote VNC server to your local machine
-    ssh -L -N 5990:localhost:localhost:5990 coder.[env-name]
+    ssh -L -N 5990:localhost:5990 coder.[env-name]
     # You will not see any output if it succeeds, but you
     # will be able to connect your VNC client to localhost:5990
     ```

--- a/images/vnc/xfce4/helpers.rc
+++ b/images/vnc/xfce4/helpers.rc
@@ -1,1 +1,1 @@
-WebBrowser=google-chrome
+WebBrowser=firefox

--- a/images/vnc/xfce4/xfconf/xfce-perchannel-xml/displays.xml
+++ b/images/vnc/xfce4/xfconf/xfce-perchannel-xml/displays.xml
@@ -1,35 +1,35 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
-<channel name="displays" version="1.0">
-  <property name="ActiveProfile" type="string" value="Default"/>
-  <property name="Default" type="empty">
-    <property name="VNC-0" type="string" value="VNC-0">
-      <property name="Active" type="bool" value="true"/>
-      <property name="EDID" type="string" value=""/>
-      <property name="Resolution" type="string" value="3840x2160"/>
-      <property name="RefreshRate" type="double" value="60.000000"/>
-      <property name="Rotation" type="int" value="0"/>
-      <property name="Reflection" type="string" value="0"/>
-      <property name="Primary" type="bool" value="false"/>
-      <property name="Position" type="empty">
-        <property name="X" type="int" value="0"/>
-        <property name="Y" type="int" value="0"/>
+<channel name="xfce4-desktop" version="1.0">
+  <property name="backdrop" type="empty">
+    <property name="screen0" type="empty">
+      <property name="monitor0" type="empty">
+        <property name="workspace0" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="4"/>
+          <property name="last-image" type="string" value="/home/coder/.config/xfce4/coder-bg.jpg"/>
+        </property>
+        <property name="workspace1" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="4"/>
+          <property name="last-image" type="string" value="/home/coder/.config/xfce4/coder-bg.jpg"/>
+        </property>
+        <property name="workspace2" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="4"/>
+          <property name="last-image" type="string" value="/home/coder/.config/xfce4/coder-bg.jpg"/>
+        </property>
+        <property name="workspace3" type="empty">
+          <property name="color-style" type="int" value="0"/>
+          <property name="image-style" type="int" value="4"/>
+          <property name="last-image" type="string" value="/home/coder/.config/xfce4/coder-bg.jpg"/>
+        </property>
+        <property name="image-path" type="string" value="/home/coder/.config/xfce4/coder-bg.jpg"/>
+        <property name="image-show" type="bool" value="true"/>
+        <property name="image-style" type="string" value="scaled"/>
       </property>
     </property>
   </property>
-  <property name="Fallback" type="empty">
-    <property name="VNC-0" type="string" value="VNC-0">
-      <property name="Active" type="bool" value="true"/>
-      <property name="EDID" type="string" value=""/>
-      <property name="Resolution" type="string" value="1900x1200"/>
-      <property name="RefreshRate" type="double" value="60.000000"/>
-      <property name="Rotation" type="int" value="0"/>
-      <property name="Reflection" type="string" value="0"/>
-      <property name="Primary" type="bool" value="false"/>
-      <property name="Position" type="empty">
-        <property name="X" type="int" value="0"/>
-        <property name="Y" type="int" value="0"/>
-      </property>
-    </property>
+  <property name="last" type="empty">
+    <property name="window-width" type="int" value="1280"/>
+    <property name="window-height" type="int" value="1024"/>
   </property>
 </channel>

--- a/images/vnc/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
+++ b/images/vnc/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml
@@ -58,10 +58,10 @@
     <property name="snap_to_windows" type="bool" value="false"/>
     <property name="snap_width" type="int" value="10"/>
     <property name="vblank_mode" type="string" value="auto"/>
-    <property name="theme" type="string" value="Default-xhdpi"/>
+    <property name="theme" type="string" value="Greybird-dark"/>
     <property name="tile_on_move" type="bool" value="true"/>
     <property name="title_alignment" type="string" value="center"/>
-    <property name="title_font" type="string" value="Sans Bold 20"/>
+    <property name="title_font" type="string" value="Sans Bold 10"/>
     <property name="title_horizontal_offset" type="int" value="0"/>
     <property name="titleless_maximize" type="bool" value="false"/>
     <property name="title_shadow_active" type="string" value="false"/>

--- a/images/vnc/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
+++ b/images/vnc/xfce4/xfconf/xfce-perchannel-xml/xsettings.xml
@@ -37,9 +37,6 @@
     <property name="DecorationLayout" type="empty"/>
   </property>
   <property name="Gdk" type="empty">
-    <property name="WindowScalingFactor" type="int" value="2"/>
-  </property>
-  <property name="Xfce" type="empty">
-    <property name="LastCustomDPI" type="int" value="112"/>
+    <property name="WindowScalingFactor" type="int" value="1"/>
   </property>
 </channel>


### PR DESCRIPTION
From the previous PR comments, it looked like VNC was configured for a 4k display. This made it difficult to browse from a laptop or even my ultrawide. These settings can always be configured by the user.

The installation method for Google Chrome led to errors. Since the desktop environment comes with firefox, I switched to that.

Also fixed a typo.