### PR TITLE
chore: ignore minor/patch versions of official actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,12 @@ updates:
     commit-message:
       prefix: "chore"
     ignore:
-      # GitHub always delivers the latest versions for each major
-      # release tag, so handle updates manually
+      # These actions deliver the latest versions by updating the
+      # major release tag, so ignore minor/patch updates
       - dependency-name: "actions/*"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
 
   - package-ecosystem: "npm"
     directory: "/"


### PR DESCRIPTION
I have no idea if this will work, but it seems worth experimenting