### PR TITLE
Added CLion image

### DIFF
--- a/images/clion/Dockerfile.centos
+++ b/images/clion/Dockerfile.centos
@@ -1,0 +1,14 @@
+FROM codercom/enterprise-multieditor:centos
+
+# Run everything as root
+USER root
+
+# Install clion.
+RUN mkdir -p /opt/clion
+RUN curl -L "https://download.jetbrains.com/product?code=CL&latest&distribution=linux" | tar -C /opt/clion --strip-components 1 -xzvf -
+
+# Add a binary to the PATH that points to the clion startup script.
+RUN ln -s /opt/clion/bin/clion.sh /usr/bin/clion
+
+# Set back to coder user
+USER coder

--- a/images/clion/Dockerfile.ubuntu
+++ b/images/clion/Dockerfile.ubuntu
@@ -1,0 +1,14 @@
+FROM codercom/enterprise-multieditor:ubuntu
+
+# Run everything as root
+USER root
+
+# Install clion.
+RUN mkdir -p /opt/clion
+RUN curl -L "https://download.jetbrains.com/product?code=CL&latest&distribution=linux" | tar -C /opt/clion --strip-components 1 -xzvf -
+
+# Add a binary to the PATH that points to the clion startup script.
+RUN ln -s /opt/clion/bin/clion.sh /usr/bin/clion
+
+# Set back to coder user
+USER coder

--- a/images/clion/README.md
+++ b/images/clion/README.md
@@ -1,0 +1,13 @@
+# Enterprise CLion
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/codercom/enterprise-clion?label=codercom%2Fenterprise-clion)](https://hub.docker.com/r/codercom/enterprise-clion)
+
+## Description
+
+Wraps [enterprise-multieditor](../multieditor/README.md) with CLion
+installation.
+
+## How To Use It
+
+This image is ready for direct use within Coder Enterprise. Environments created
+from this image will be able to launch CLion.

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -20,4 +20,5 @@ IMAGES=(
   "ruby"
   "vnc"
   "webstorm"
+  "clion"
 )


### PR DESCRIPTION
This MR adds the Jetbrains clion image since clion is supported by coder and there has not been an image for it yet.

Sources: 
- https://coder.com/docs/coder/v1.19/workspaces/editors#jetbrains-ides-in-the-browser
- https://www.jetbrains.com/de-de/clion/