### PR TITLE
chore: downgrade openjdk from v14 to 11 (LTS)

### DIFF
--- a/images/java/Dockerfile.ubuntu
+++ b/images/java/Dockerfile.ubuntu
@@ -4,8 +4,8 @@ FROM codercom/enterprise-base:ubuntu
 USER root
 
 # Install JDK (OpenJDK 8)
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-14-jdk
-ENV JAVA_HOME /usr/lib/jvm/java-14-openjdk-amd64
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y openjdk-11-jdk
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH $PATH:$JAVA_HOME/bin
 
 # Install Maven


### PR DESCRIPTION
OpenJDK 14 appears to have disappeared from the Ubuntu focal
repository, so downgrade OpenJDK to the most recent LTS version,
which is version 11.