### PR TITLE
update go version to 1.17.1

### DIFF
--- a/images/golang/Dockerfile.centos
+++ b/images/golang/Dockerfile.centos
@@ -3,7 +3,7 @@ FROM codercom/enterprise-base:centos
 # Run everything as root
 USER root
 
-# Install go1.15
+# Install go
 RUN curl -L "https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
 
 # Setup go env vars

--- a/images/golang/Dockerfile.centos
+++ b/images/golang/Dockerfile.centos
@@ -4,7 +4,7 @@ FROM codercom/enterprise-base:centos
 USER root
 
 # Install go1.15
-RUN curl -L "https://dl.google.com/go/go1.15.3.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
+RUN curl -L "https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
 
 # Setup go env vars
 ENV GOROOT /usr/local/go

--- a/images/golang/Dockerfile.ubuntu
+++ b/images/golang/Dockerfile.ubuntu
@@ -4,7 +4,7 @@ FROM codercom/enterprise-base:ubuntu
 USER root
 
 # Install go1.15
-RUN curl -L "https://dl.google.com/go/go1.15.3.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
+RUN curl -L "https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
 
 # Setup go env vars
 ENV GOROOT /usr/local/go

--- a/images/golang/Dockerfile.ubuntu
+++ b/images/golang/Dockerfile.ubuntu
@@ -3,7 +3,7 @@ FROM codercom/enterprise-base:ubuntu
 # Run everything as root
 USER root
 
-# Install go1.15
+# Install go
 RUN curl -L "https://dl.google.com/go/go1.17.1.linux-amd64.tar.gz" | tar -C /usr/local -xzvf -
 
 # Setup go env vars


### PR DESCRIPTION
updating our golang images to include the latest stable version of go, `1.17.1`, based on [feedback from a hosted beta user](https://codercom.slack.com/archives/C02EK5ZB2R1/p1632339194053600). if there's any way for us to automate this process, let me know. I'd like to learn how to implement such automation into the images.