### PR TITLE
fix: missing golang from goland image

### DIFF
--- a/images/goland/Dockerfile.centos
+++ b/images/goland/Dockerfile.centos
@@ -4,12 +4,14 @@ FROM codercom/enterprise-golang:centos
 USER root
 
 # Packages required for multi-editor support
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
-    libxtst6 \
-    libxrender1 \
-    libfontconfig1 \
-    libxi6 \
-    libgtk-3-0
+RUN yum update -y && yum install -y \
+    openssl \
+    libXtst \
+    libXrender \
+    fontconfig \
+    libXi \
+    gtk3 \
+    libGL
 
 # Install goland.
 RUN mkdir -p /opt/goland

--- a/images/goland/Dockerfile.centos
+++ b/images/goland/Dockerfile.centos
@@ -1,7 +1,15 @@
-FROM codercom/enterprise-multieditor:centos
+FROM codercom/enterprise-golang:centos
 
 # Run everything as root
 USER root
+
+# Packages required for multi-editor support
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    libxtst6 \
+    libxrender1 \
+    libfontconfig1 \
+    libxi6 \
+    libgtk-3-0
 
 # Install goland.
 RUN mkdir -p /opt/goland

--- a/images/goland/Dockerfile.ubuntu
+++ b/images/goland/Dockerfile.ubuntu
@@ -1,7 +1,15 @@
-FROM codercom/enterprise-multieditor:ubuntu
+FROM codercom/enterprise-golang:ubuntu
 
 # Run everything as root
 USER root
+
+# Packages required for multi-editor support
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y \
+    libxtst6 \
+    libxrender1 \
+    libfontconfig1 \
+    libxi6 \
+    libgtk-3-0
 
 # Install goland.
 RUN mkdir -p /opt/goland

--- a/images/goland/README.md
+++ b/images/goland/README.md
@@ -4,7 +4,7 @@
 
 ## Description
 
-Wraps [enterprise-multieditor](../multieditor/README.md) with GoLand
+Wraps [enterprise-golang](../golang/README.md) and includes [required multi-editor dependencies](https://enterprise.coder.com/docs/installing-an-ide-onto-your-image#required-packages) with GoLand
 installation.
 
 ## How To Use It


### PR DESCRIPTION
Using the GoLand JetBrains does not include Golang rendering a poor experience.  Adding enterprise-golang in lieu of multieditor image, and paste multieditor dependencies in GoLand image for JetBrains IDEs to continue to work in Projector (browser)