### PR TITLE
chore: fix node image to fall back to node 22 for armv7

### DIFF
--- a/images/node/ubuntu.Dockerfile
+++ b/images/node/ubuntu.Dockerfile
@@ -3,9 +3,19 @@ FROM codercom/enterprise-base:ubuntu
 # Run everything as root
 USER root
 
-# Install whichever Node version is LTS
-RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash -
-RUN DEBIAN_FRONTEND="noninteractive" apt-get update -y && \
+ARG TARGETARCH
+ARG TARGETVARIANT
+
+# Install Node.js with platform-specific version
+# armv7: Node.js 22.x (last version with armv7 support)
+# others: Latest LTS
+# Ref: https://github.com/nodesource/distributions/issues/1881
+RUN NODE_VERSION="lts"; \
+    if [ "${TARGETARCH}${TARGETVARIANT}" = "armv7" ]; then \
+        NODE_VERSION="22"; \
+    fi && \
+    curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    DEBIAN_FRONTEND="noninteractive" apt-get update -y && \
     apt-get install -y nodejs
 
 # Install Yarn

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 
+# IMAGES defines the list of images to build/push IN ORDER.
 IMAGES=(
   "base"
   "minimal"


### PR DESCRIPTION
The build job has been failing for the last couple of months: https://github.com/coder/images/actions/workflows/build.yaml?query=branch%3Amain

Error: 
```
  #28 33.26 2025-11-24 02:36:29 - Error: Unsupported architecture: armhf. Only amd64, arm64 are supported. Contact Nodesource for an extended support version https://nodesource.com/pages/contact-us.html. (Exit Code: 1)

```

Fix: install Node version 22 on arm/v7 and LTS on other platforms.