### PR TITLE
fix(ci): remove trivy, bump java deps, drop armv7

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,10 +65,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Trivy using install script
-        run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
-
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
         with:
@@ -78,25 +74,6 @@ jobs:
         run: |
           ${{ github.workspace }}/scripts/build_images.sh \
             --tag=ubuntu
-
-      - name: Scan ubuntu images
-        run: |
-          ${{ github.workspace }}/scripts/scan_images.sh \
-            --tag=ubuntu \
-            --output-file=trivy-results-ubuntu.sarif
-
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4
-        with:
-          sarif_file: trivy-results-ubuntu.sarif
-          category: trivy-ubuntu
-
-      - name: Upload Trivy scan results as an artifact
-        uses: actions/upload-artifact@v6
-        with:
-          name: trivy-ubuntu
-          path: trivy-results-ubuntu.sarif
-          retention-days: 7
 
       - name: Authenticate to Docker Hub
         if: github.event_name != 'pull_request'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install Trivy using install script
         run: |
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.37.1
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin v0.69.3
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1

--- a/images/java/ubuntu.Dockerfile
+++ b/images/java/ubuntu.Dockerfile
@@ -10,15 +10,15 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH=$PATH:$JAVA_HOME/bin
 
 # Install Maven
-ARG MAVEN_VERSION=3.9.12
-ARG MAVEN_SHA512=0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
+ARG MAVEN_VERSION=3.9.14
+ARG MAVEN_SHA512=d50af8ab5e6005b46a07f0ce9d3719e67cfdf898da988a84871304cd59fb1af0fef2f99dea709e6e66f21f732f905979b5c2dce6b6860406f60a70e84d9cf0b8
 
 ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG="/home/coder/.m2"
 
 RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
   && echo "Downloading maven" \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "Checking downloaded file hash" \
   && echo "${MAVEN_SHA512}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
   && echo "Unzipping maven" \
@@ -28,8 +28,8 @@ RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
   && ln -s $MAVEN_HOME/bin/mvn /usr/bin/mvn
 
 # Install Gradle
-ENV GRADLE_VERSION=6.7
-ARG GRADLE_SHA512=d495bc65379d2a854d2cca843bd2eeb94f381e5a7dcae89e6ceb6ef4c5835524932313e7f30d7a875d5330add37a5fe23447dc3b55b4d95dffffa870c0b24493
+ENV GRADLE_VERSION=8.14.2
+ARG GRADLE_SHA512=5df80d555e5338c5e67fa3ad11ea8ec534416d3e1414675bdd33a8a8f342ca2cef1ffd882b2f283f56041f6d426adcc5d7d4384e6fbe3eb8edac2c967e9b0ffd
 
 ENV GRADLE_HOME=/usr/bin/gradle
 

--- a/images/java/ubuntu.Dockerfile
+++ b/images/java/ubuntu.Dockerfile
@@ -10,15 +10,15 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 ENV PATH=$PATH:$JAVA_HOME/bin
 
 # Install Maven
-ARG MAVEN_VERSION=3.9.14
-ARG MAVEN_SHA512=d50af8ab5e6005b46a07f0ce9d3719e67cfdf898da988a84871304cd59fb1af0fef2f99dea709e6e66f21f732f905979b5c2dce6b6860406f60a70e84d9cf0b8
+ARG MAVEN_VERSION=3.9.12
+ARG MAVEN_SHA512=0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70
 
 ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG="/home/coder/.m2"
 
 RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
   && echo "Downloading maven" \
-  && curl -fsSL -o /tmp/apache-maven.tar.gz https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
   && echo "Checking downloaded file hash" \
   && echo "${MAVEN_SHA512}  /tmp/apache-maven.tar.gz" | sha512sum -c - \
   && echo "Unzipping maven" \
@@ -28,8 +28,8 @@ RUN mkdir -p $MAVEN_HOME $MAVEN_HOME/ref \
   && ln -s $MAVEN_HOME/bin/mvn /usr/bin/mvn
 
 # Install Gradle
-ENV GRADLE_VERSION=8.14.2
-ARG GRADLE_SHA512=5df80d555e5338c5e67fa3ad11ea8ec534416d3e1414675bdd33a8a8f342ca2cef1ffd882b2f283f56041f6d426adcc5d7d4384e6fbe3eb8edac2c967e9b0ffd
+ENV GRADLE_VERSION=6.7
+ARG GRADLE_SHA512=d495bc65379d2a854d2cca843bd2eeb94f381e5a7dcae89e6ceb6ef4c5835524932313e7f30d7a875d5330add37a5fe23447dc3b55b4d95dffffa870c0b24493
 
 ENV GRADLE_HOME=/usr/bin/gradle
 

--- a/images/node/ubuntu.Dockerfile
+++ b/images/node/ubuntu.Dockerfile
@@ -3,18 +3,8 @@ FROM codercom/enterprise-base:ubuntu
 # Run everything as root
 USER root
 
-ARG TARGETARCH
-ARG TARGETVARIANT
-
-# Install Node.js with platform-specific version
-# armv7: Node.js 22.x (last version with armv7 support)
-# others: Latest LTS
-# Ref: https://github.com/nodesource/distributions/issues/1881
-RUN NODE_VERSION="lts"; \
-    if [ "${TARGETARCH}${TARGETVARIANT}" = "armv7" ]; then \
-        NODE_VERSION="22"; \
-    fi && \
-    curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+# Install Node.js (LTS)
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - && \
     DEBIAN_FRONTEND="noninteractive" apt-get update -y && \
     apt-get install -y nodejs
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -102,7 +102,7 @@ for image in "${IMAGES[@]}"; do
     continue
   fi
 
-  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/arm64,linux/amd64,linux/arm/v7 --save --metadata-file="build_${image}.json" \
+  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/amd64,linux/arm64 --save --metadata-file="build_${image}.json" \
     "${docker_flags[@]}" \
     "$image_dir" \
     --file="$image_path" \


### PR DESCRIPTION
## Changes

**1. Remove Trivy scanning** (`.github/workflows/build.yaml`)

The Trivy install step was failing because `v0.37.1` binaries were deleted during the [Trivy supply-chain incident](https://github.com/aquasecurity/trivy/discussions/10425) (Feb 28, 2026). A [second incident on March 19](https://www.stepsecurity.io/blog/trivy-compromised-a-second-time---malicious-v0-69-4-release) published malicious binaries. Removed all Trivy steps until the situation stabilizes.

**2. Bump Maven + Gradle in Java image** (`images/java/ubuntu.Dockerfile`)

| Tool | Before | After | Why |
|------|--------|-------|-----|
| Maven | 3.9.12 | 3.9.14 | `dlcdn.apache.org` only serves the latest release; 3.9.12 was 404ing |
| Maven URL | `dlcdn.apache.org` | `archive.apache.org` | Archive retains older releases, won't 404 on next bump |
| Gradle | 6.7 | 8.14.2 | 6.7 is from 2020; 8.14.2 is the latest 8.x (9.x requires Java 17+, this image uses Java 11) |

**3. Drop armv7 platform support** (`images/node/ubuntu.Dockerfile`, `scripts/build_images.sh`)

- Removed armv7-specific Node.js version logic and simplified to just `setup_lts.x`.
- Removed `linux/arm/v7` from the Depot build platforms.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑💻