### PR TITLE
chore: drop linux/arm/v7 platform support

### DIFF
--- a/images/node/ubuntu.Dockerfile
+++ b/images/node/ubuntu.Dockerfile
@@ -3,18 +3,8 @@ FROM codercom/enterprise-base:ubuntu
 # Run everything as root
 USER root
 
-ARG TARGETARCH
-ARG TARGETVARIANT
-
-# Install Node.js with platform-specific version
-# armv7: Node.js 22.x (last version with armv7 support)
-# others: Latest LTS
-# Ref: https://github.com/nodesource/distributions/issues/1881
-RUN NODE_VERSION="lts"; \
-    if [ "${TARGETARCH}${TARGETVARIANT}" = "armv7" ]; then \
-        NODE_VERSION="22"; \
-    fi && \
-    curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+# Install Node.js (LTS)
+RUN curl -sL https://deb.nodesource.com/setup_lts.x | bash - && \
     DEBIAN_FRONTEND="noninteractive" apt-get update -y && \
     apt-get install -y nodejs
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -102,7 +102,7 @@ for image in "${IMAGES[@]}"; do
     continue
   fi
 
-  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/arm64,linux/amd64,linux/arm/v7 --save --metadata-file="build_${image}.json" \
+  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/amd64,linux/arm64 --save --metadata-file="build_${image}.json" \
     "${docker_flags[@]}" \
     "$image_dir" \
     --file="$image_path" \


### PR DESCRIPTION
NodeSource no longer provides Node.js binaries for armhf (32-bit ARM / arm/v7). This has been breaking the `images/ubuntu` build job.

## Changes
- Remove `linux/arm/v7` from the `--platform` list in `build_images.sh`
- Remove the armv7 Node.js version workaround and unused `TARGETARCH`/`TARGETVARIANT` ARGs from `images/node/ubuntu.Dockerfile`

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑💻