### PR TITLE
fix: add universal image to build and push list

### DIFF
--- a/images/universal/.platforms
+++ b/images/universal/.platforms
@@ -1,0 +1,1 @@
+linux/amd64

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -88,6 +88,8 @@ if [ $QUIET = true ]; then
   )
 fi
 
+DEFAULT_PLATFORM="linux/amd64,linux/arm64"
+
 for image in "${IMAGES[@]}"; do
   image_dir="$PROJECT_ROOT/images/$image"
   image_file="${TAG}.Dockerfile"
@@ -102,7 +104,13 @@ for image in "${IMAGES[@]}"; do
     continue
   fi
 
-  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform linux/amd64,linux/arm64 --save --metadata-file="build_${image}.json" \
+  # Allow per-image platform override via a .platforms file.
+  platform="$DEFAULT_PLATFORM"
+  if [ -f "$image_dir/.platforms" ]; then
+    platform=$(cat "$image_dir/.platforms")
+  fi
+
+  run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform "$platform" --save --metadata-file="build_${image}.json" \
     "${docker_flags[@]}" \
     "$image_dir" \
     --file="$image_path" \

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -10,4 +10,5 @@ IMAGES=(
   "java"
   "node"
   "desktop"
+  "universal"
 )


### PR DESCRIPTION
The `universal` image was added in #307 but never included in the `IMAGES` array in `scripts/images.sh`. Both `build_images.sh` and `push_images.sh` iterate over this array, so the universal image was never built or pushed to Docker Hub.

## Changes

- Add `"universal"` to the `IMAGES` array in `scripts/images.sh`.
- Add per-image platform override support via `.platforms` file — if present in the image directory, its content is used as the `--platform` value instead of the default.
- Add `images/universal/.platforms` with `linux/amd64` only, since `mcr.microsoft.com/devcontainers/universal:linux` has no arm64 variant.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review. 🧑💻