### PR TITLE
feat: add ubuntu version-specific image tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.sarif
 tmp.*
+build_*.json

--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ https://hub.docker.com/r/codercom/example-base. The tag is taken from the
 filename of the Dockerfile. For example, `base/ubuntu.Dockerfile` is
 under the `ubuntu` tag.
 
+### Available Tags
+
+Each image is published with the following tag variants:
+
+| Tag                       | Example                                       | Description                                        |
+| ------------------------- | --------------------------------------------- | -------------------------------------------------- |
+| `ubuntu`                  | `codercom/example-base:ubuntu`                | Latest Ubuntu version (rolling)                    |
+| `ubuntu-{version}`        | `codercom/example-base:ubuntu-noble`          | Pinned to a specific Ubuntu release                |
+| `ubuntu-{date}`           | `codercom/example-base:ubuntu-20250101`       | Snapshot from a specific build date                |
+| `ubuntu-{version}-{date}` | `codercom/example-base:ubuntu-noble-20250101` | Version-pinned snapshot from a specific build date |
+| `latest`                  | `codercom/example-base:latest`                | Alias for the latest build                         |
+
 > For backward compatibility, these images are also available with the `enterprise-` prefix
 > (e.g., `codercom/enterprise-base`), but the `example-` prefix is recommended for new deployments.
 

--- a/images/base/ubuntu.Dockerfile
+++ b/images/base/ubuntu.Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:noble
+ARG UBUNTU_VERSION=noble
+FROM ubuntu:${UBUNTU_VERSION}
 
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND=noninteractive

--- a/images/minimal/ubuntu.Dockerfile
+++ b/images/minimal/ubuntu.Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:noble
+ARG UBUNTU_VERSION=noble
+FROM ubuntu:${UBUNTU_VERSION}
 
 USER root
 ENV DEBIAN_FRONTEND=noninteractive

--- a/images/universal/ubuntu.Dockerfile
+++ b/images/universal/ubuntu.Dockerfile
@@ -1,4 +1,5 @@
-FROM mcr.microsoft.com/devcontainers/universal:linux
+ARG UBUNTU_VERSION=noble
+FROM mcr.microsoft.com/devcontainers/universal:${UBUNTU_VERSION}
 
 USER root
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -111,6 +111,7 @@ for image in "${IMAGES[@]}"; do
   fi
 
   run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform "$platform" --save --metadata-file="build_${image}.json" \
+    --build-arg "UBUNTU_VERSION=$UBUNTU_VERSION" \
     "${docker_flags[@]}" \
     "$image_dir" \
     --file="$image_path" \

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -2,6 +2,12 @@
 
 set -euo pipefail
 
+# UBUNTU_VERSION defines the Ubuntu release used as the base for all
+# images. Changing this value and rebuilding will produce images on
+# a different Ubuntu release. All Dockerfiles and the push script
+# read this variable so it acts as a single source of truth.
+UBUNTU_VERSION="noble"
+
 # IMAGES defines the list of images to build/push IN ORDER.
 IMAGES=(
   "base"

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -106,14 +106,22 @@ for image in "${IMAGES[@]}"; do
   fi
 
   build_id=$(cat "build_${image}.json" | jq -r .\[\"depot.build\"\].buildID)
-  
+
   # Push example images (primary)
   run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$example_image_ref" "$build_id"
   run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$example_image_ref_date" "$build_id"
   run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/example-${image}:latest" "$build_id"
-  
+
   # Push enterprise images (alias)
   run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$enterprise_image_ref" "$build_id"
   run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "$enterprise_image_ref_date" "$build_id"
   run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/enterprise-${image}:latest" "$build_id"
+
+  # Push version-specific tags so users can pin to a specific Ubuntu
+  # release. UBUNTU_VERSION is defined in images.sh and is the single
+  # source of truth used by both the Dockerfiles and this script.
+  for prefix in "example" "enterprise"; do
+    run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/${prefix}-${image}:${TAG}-${UBUNTU_VERSION}" "$build_id"
+    run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/${prefix}-${image}:${TAG}-${UBUNTU_VERSION}-${date_str}" "$build_id"
+  done
 done


### PR DESCRIPTION
## Summary

Adds Ubuntu version-specific image tags so users can pin to a specific Ubuntu release and avoid unexpected breakage when the base image changes.

## Problem

The `:ubuntu` tag is rolling — it follows whatever Ubuntu version the Dockerfiles currently use. When we bump versions (e.g., 22.04 → 24.04), workspaces can break unexpectedly, as reported in #282.

## Approach

Define `UBUNTU_VERSION` once in `scripts/images.sh`. Everything else reads that variable:

- **Dockerfiles** consume it via `ARG UBUNTU_VERSION` in their `FROM` line
- **Build script** passes it as `--build-arg`
- **Push script** uses it directly to generate version-specific tags

No runtime detection, no sidecar files, no `docker run` at push time.

## Changes

- `scripts/images.sh` — Added `UBUNTU_VERSION="noble"` as the single source of truth
- `images/base/ubuntu.Dockerfile` — `FROM ubuntu:${UBUNTU_VERSION}`
- `images/minimal/ubuntu.Dockerfile` — `FROM ubuntu:${UBUNTU_VERSION}`
- `images/universal/ubuntu.Dockerfile` — `FROM mcr.microsoft.com/devcontainers/universal:${UBUNTU_VERSION}`
- `scripts/build_images.sh` — Passes `--build-arg UBUNTU_VERSION`
- `scripts/push_images.sh` — Pushes `ubuntu-{version}` and `ubuntu-{version}-{date}` tags
- `README.md` — Tag reference table
- Derivative images (golang, java, node, desktop) unchanged — they inherit from locally-built base/minimal

Closes #282

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻