### PR TITLE
images/universal: preserve upstream user environment when switching to coder

### DIFF
--- a/images/universal/README.md
+++ b/images/universal/README.md
@@ -4,4 +4,4 @@
 
 ## Description
 
-Microsoft's [Universal Dev Container Image](https://github.com/devcontainers/images/tree/main/src/universal) extended with a `coder` user.
+Microsoft's [Universal Dev Container Image](https://github.com/devcontainers/images/tree/main/src/universal) with the upstream `codespace` user renamed to `coder` so the base image's home directory and shell environment are preserved.

--- a/images/universal/ubuntu.Dockerfile
+++ b/images/universal/ubuntu.Dockerfile
@@ -12,14 +12,12 @@ RUN rm -R /opt/conda && \
 # Install Chrome for AI Browser Testing
 RUN yes | npx playwright install chrome
 
-# Create `coder` user
-RUN userdel -r codespace && \
-    useradd coder \
-    --create-home \
-    --shell=/bin/bash \
-    --groups=docker \
-    --uid=1000 \
-    --user-group && \
-echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
+# Rename the upstream `codespace` user to `coder` so we preserve the
+# existing home directory and shell environment provided by the base image.
+RUN usermod -l coder codespace && \
+    groupmod -n coder codespace && \
+    usermod -d /home/coder -m coder && \
+    usermod -aG docker,sudo coder && \
+    echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
 
 USER coder


### PR DESCRIPTION
## Summary

Rename the upstream `codespace` user to `coder` instead of deleting it and creating a fresh account.

## Why

The universal image is built on top of `mcr.microsoft.com/devcontainers/universal`, which is configured around the existing `codespace` user and its home directory. Recreating the user leaves behind shell and PATH behavior that still assumes `/home/codespace`.

In Coder workspaces this can surface as login shells dropping the injected `coder` CLI from `PATH`, causing `coder: command not found` in some terminal flows.

I reproduced that behavior in a real workspace from the Docker template:

- `bash -c 'command -v coder'` works
- `bash -lc 'command -v coder'` fails

Preserving the upstream account avoids that mismatch and keeps the base image's home directory and shell environment coherent.

## Changes

- replace `userdel -r codespace` + `useradd coder` with `usermod/groupmod`
- move the home directory to `/home/coder`
- keep `coder` in the `docker` and `sudo` groups
- update the universal image README to describe the approach

## Expected result

Login-shell behavior remains consistent with the upstream devcontainer image while still exposing the user as `coder` for Coder workspaces.
