### PR TITLE
fix(universal): preserve login shell PATH for coder user

### DIFF
--- a/images/universal/README.md
+++ b/images/universal/README.md
@@ -4,4 +4,4 @@
 
 ## Description
 
-Microsoft's [Universal Dev Container Image](https://github.com/devcontainers/images/tree/main/src/universal) extended with a `coder` user.
+Microsoft's [Universal Dev Container Image](https://github.com/devcontainers/images/tree/main/src/universal) with the upstream `codespace` user renamed to `coder`. The image keeps the base shell environment while rewriting hardcoded home paths and preserving inherited `PATH` entries for Coder's injected tooling.

--- a/images/universal/ubuntu.Dockerfile
+++ b/images/universal/ubuntu.Dockerfile
@@ -12,14 +12,22 @@ RUN rm -R /opt/conda && \
 # Install Chrome for AI Browser Testing
 RUN yes | npx playwright install chrome
 
-# Create `coder` user
-RUN userdel -r codespace && \
-    useradd coder \
-    --create-home \
-    --shell=/bin/bash \
-    --groups=docker \
-    --uid=1000 \
-    --user-group && \
-echo "coder ALL=(ALL) NOPASSWD:ALL" >>/etc/sudoers.d/nopasswd
+# Rename the upstream `codespace` user to `coder` so we preserve the
+# existing home directory and shell environment provided by the base image.
+RUN usermod -l coder codespace && \
+    groupmod -n coder codespace && \
+    usermod -d /home/coder -m coder && \
+    usermod -aG docker,sudo coder && \
+    sed -i \
+        -e 's#/home/codespace#/home/coder#g' \
+        -e 's#^export PATH=#export PATH=${PATH:+$PATH:}#' \
+        /etc/profile.d/00-restore-env.sh && \
+    sed -i \
+        -e 's#codespace#coder#g' \
+        -e 's#/home/codespace#/home/coder#g' \
+        /etc/sudoers.d/codespace && \
+    mv /etc/sudoers.d/codespace /etc/sudoers.d/coder && \
+    echo "coder ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/nopasswd && \
+    chmod 0440 /etc/sudoers.d/coder /etc/sudoers.d/nopasswd
 
 USER coder


### PR DESCRIPTION
The universal image previously deleted the upstream `codespace` user and recreated `coder`, which left login-shell environment behavior inconsistent with the Microsoft devcontainer base image.

Rename the upstream user in place, move its home directory to `/home/coder`, rewrite the base image's hardcoded home paths, and preserve inherited `PATH` entries so Coder's injected CLI stays available in login shells.

Replaces #331.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻
