### PR TITLE
feat: migrate images to Ubuntu 26.04 (resolute)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,13 @@ under the `ubuntu` tag.
 
 Each image is published with the following tag variants:
 
-| Tag                       | Example                                       | Description                                        |
-| ------------------------- | --------------------------------------------- | -------------------------------------------------- |
-| `ubuntu`                  | `codercom/example-base:ubuntu`                | Latest Ubuntu version (rolling)                    |
-| `ubuntu-{version}`        | `codercom/example-base:ubuntu-noble`          | Pinned to a specific Ubuntu release                |
-| `ubuntu-{date}`           | `codercom/example-base:ubuntu-20250101`       | Snapshot from a specific build date                |
-| `ubuntu-{version}-{date}` | `codercom/example-base:ubuntu-noble-20250101` | Version-pinned snapshot from a specific build date |
-| `latest`                  | `codercom/example-base:latest`                | Alias for the latest build                         |
+| Tag                       | Example                                          | Description                                        |
+| ------------------------- | ------------------------------------------------ | -------------------------------------------------- |
+| `ubuntu`                  | `codercom/example-base:ubuntu`                   | Latest Ubuntu version (rolling)                    |
+| `ubuntu-{version}`        | `codercom/example-base:ubuntu-resolute`          | Pinned to a specific Ubuntu release                |
+| `ubuntu-{date}`           | `codercom/example-base:ubuntu-20250101`          | Snapshot from a specific build date                |
+| `ubuntu-{version}-{date}` | `codercom/example-base:ubuntu-resolute-20250101` | Version-pinned snapshot from a specific build date |
+| `latest`                  | `codercom/example-base:latest`                   | Alias for the latest build                         |
 
 > For backward compatibility, these images are also available with the `enterprise-` prefix
 > (e.g., `codercom/enterprise-base`), but the `example-` prefix is recommended for new deployments.

--- a/images/base/docker.list
+++ b/images/base/docker.list
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu noble stable
+deb [signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu resolute stable

--- a/images/base/ubuntu.Dockerfile
+++ b/images/base/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-ARG UBUNTU_VERSION=noble
+ARG UBUNTU_VERSION=resolute
 FROM ubuntu:${UBUNTU_VERSION}
 
 SHELL ["/bin/bash", "-c"]

--- a/images/minimal/ubuntu.Dockerfile
+++ b/images/minimal/ubuntu.Dockerfile
@@ -1,4 +1,4 @@
-ARG UBUNTU_VERSION=noble
+ARG UBUNTU_VERSION=resolute
 FROM ubuntu:${UBUNTU_VERSION}
 
 USER root

--- a/images/universal/ubuntu.Dockerfile
+++ b/images/universal/ubuntu.Dockerfile
@@ -1,7 +1,8 @@
-# Pinned to noble because Microsoft's devcontainers/universal image does not
-# yet publish a resolute (26.04) tag. Re-couple this to the shared
-# UBUNTU_VERSION build arg once an upstream resolute tag is available.
-FROM mcr.microsoft.com/devcontainers/universal:noble
+# UBUNTU_VERSION is pinned to noble via UBUNTU_VERSION_OVERRIDES in
+# scripts/images.sh because Microsoft's devcontainers/universal image does
+# not yet publish a resolute (26.04) tag. See coder/images#335.
+ARG UBUNTU_VERSION=noble
+FROM mcr.microsoft.com/devcontainers/universal:${UBUNTU_VERSION}
 
 USER root
 

--- a/images/universal/ubuntu.Dockerfile
+++ b/images/universal/ubuntu.Dockerfile
@@ -1,5 +1,7 @@
-ARG UBUNTU_VERSION=noble
-FROM mcr.microsoft.com/devcontainers/universal:${UBUNTU_VERSION}
+# Pinned to noble because Microsoft's devcontainers/universal image does not
+# yet publish a resolute (26.04) tag. Re-couple this to the shared
+# UBUNTU_VERSION build arg once an upstream resolute tag is available.
+FROM mcr.microsoft.com/devcontainers/universal:noble
 
 USER root
 

--- a/scripts/build_images.sh
+++ b/scripts/build_images.sh
@@ -111,7 +111,7 @@ for image in "${IMAGES[@]}"; do
   fi
 
   run_trace $DRY_RUN depot build --project "gb3p8xrshk" --load --platform "$platform" --save --metadata-file="build_${image}.json" \
-    --build-arg "UBUNTU_VERSION=$UBUNTU_VERSION" \
+    --build-arg "UBUNTU_VERSION=$(ubuntu_version_for "$image")" \
     "${docker_flags[@]}" \
     "$image_dir" \
     --file="$image_path" \

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # images. Changing this value and rebuilding will produce images on
 # a different Ubuntu release. All Dockerfiles and the push script
 # read this variable so it acts as a single source of truth.
-UBUNTU_VERSION="noble"
+UBUNTU_VERSION="resolute"
 
 # IMAGES defines the list of images to build/push IN ORDER.
 IMAGES=(

--- a/scripts/images.sh
+++ b/scripts/images.sh
@@ -8,6 +8,24 @@ set -euo pipefail
 # read this variable so it acts as a single source of truth.
 UBUNTU_VERSION="resolute"
 
+# UBUNTU_VERSION_OVERRIDES pins individual images to a different Ubuntu
+# release than the default UBUNTU_VERSION above. It drives both the build
+# arg and the version-specific push tags, so an overridden image is tagged
+# with the release it is actually built from rather than the default.
+#
+# universal is pinned to noble because Microsoft's devcontainers/universal
+# image does not yet publish a resolute (26.04) tag. See coder/images#335.
+declare -A UBUNTU_VERSION_OVERRIDES=(
+  ["universal"]="noble"
+)
+
+# ubuntu_version_for prints the Ubuntu release for the given image, using an
+# override when present and falling back to the default UBUNTU_VERSION.
+ubuntu_version_for() {
+  local image="$1"
+  echo "${UBUNTU_VERSION_OVERRIDES[$image]:-$UBUNTU_VERSION}"
+}
+
 # IMAGES defines the list of images to build/push IN ORDER.
 IMAGES=(
   "base"

--- a/scripts/push_images.sh
+++ b/scripts/push_images.sh
@@ -118,10 +118,12 @@ for image in "${IMAGES[@]}"; do
   run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/enterprise-${image}:latest" "$build_id"
 
   # Push version-specific tags so users can pin to a specific Ubuntu
-  # release. UBUNTU_VERSION is defined in images.sh and is the single
-  # source of truth used by both the Dockerfiles and this script.
+  # release. The version comes from images.sh (the single source of
+  # truth) via ubuntu_version_for, which honours per-image overrides so
+  # each image is tagged with the release it is actually built from.
+  image_ubuntu_version="$(ubuntu_version_for "$image")"
   for prefix in "example" "enterprise"; do
-    run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/${prefix}-${image}:${TAG}-${UBUNTU_VERSION}" "$build_id"
-    run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/${prefix}-${image}:${TAG}-${UBUNTU_VERSION}-${date_str}" "$build_id"
+    run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/${prefix}-${image}:${TAG}-${image_ubuntu_version}" "$build_id"
+    run_trace $DRY_RUN depot push --project "gb3p8xrshk" --tag "codercom/${prefix}-${image}:${TAG}-${image_ubuntu_version}-${date_str}" "$build_id"
   done
 done


### PR DESCRIPTION
## Summary

Migrate the images to the newly released Ubuntu 26.04 LTS (`resolute`). `UBUNTU_VERSION` in `scripts/images.sh` is the single source of truth, so the Ubuntu-native images and everything that inherits from them roll forward from one change.

## Changes

- `scripts/images.sh`: `UBUNTU_VERSION` `noble` → `resolute`; added `UBUNTU_VERSION_OVERRIDES` + `ubuntu_version_for` helper to pin individual images to a different release.
- `images/base/ubuntu.Dockerfile`: `ARG UBUNTU_VERSION` default → `resolute`
- `images/minimal/ubuntu.Dockerfile`: `ARG UBUNTU_VERSION` default → `resolute`
- `images/base/docker.list`: Docker apt suite `noble` → `resolute`
- `README.md`: tag examples `ubuntu-noble` → `ubuntu-resolute`
- `images/universal/ubuntu.Dockerfile`: pinned to `noble` via the override (see note)
- `scripts/build_images.sh` / `scripts/push_images.sh`: resolve the Ubuntu release per image via `ubuntu_version_for`, so both the build arg and the version-specific tags reflect the release each image is actually built from.

`golang`, `java`, `node`, and `desktop` need no file changes; they inherit from `base`/`minimal` and roll forward automatically.

## Validation

Verified upstream availability of the required `resolute` bases:

| Dependency | `resolute` available? |
| --- | --- |
| `ubuntu:resolute` / `ubuntu:26.04` | ✅ |
| `download.docker.com/linux/ubuntu resolute stable` | ✅ |
| `mcr.microsoft.com/devcontainers/universal:resolute` | ❌ (latest codename tag is `noble`) |

Verified per-image tag resolution:

```
base       -> ubuntu-resolute
minimal    -> ubuntu-resolute
golang     -> ubuntu-resolute
java       -> ubuntu-resolute
node       -> ubuntu-resolute
desktop    -> ubuntu-resolute
universal  -> ubuntu-noble
```

> [!NOTE]
> The `universal` image is built from `mcr.microsoft.com/devcontainers/universal`, which does not yet publish a `resolute` tag. It's pinned to `noble` via `UBUNTU_VERSION_OVERRIDES`, which also ensures it is published as `ubuntu-noble` (not mislabeled as `ubuntu-resolute`). Tracked in #335 to re-couple once upstream publishes a `resolute` tag.

> [!CAUTION]
> Not built locally. CI / a Depot build is the validation gate before merge.

> 🤖 This PR was created with the help of Coder Agents, and needs a human review.  🧑💻
